### PR TITLE
Running master and multipaper container as non-root configurable users

### DIFF
--- a/templates/master-statefulset.yaml
+++ b/templates/master-statefulset.yaml
@@ -18,6 +18,11 @@ spec:
         {{- include "multipaper-helm.master.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "multipaper-helm.serviceAccount.name" . }}
+      securityContext:
+          runAsNonRoot: true
+          runAsUser: {{ .Values.master.uid }}
+          runAsGroup: {{ .Values.master.gid }}
+          fsGroup: {{ .Values.master.gid }}
       containers:
         - name: {{ .Chart.Name }}-master
           image: "{{ .Values.master.image.repository }}:{{ .Values.master.image.tag | default .Chart.AppVersion }}"

--- a/templates/master-statefulset.yaml
+++ b/templates/master-statefulset.yaml
@@ -19,10 +19,10 @@ spec:
     spec:
       serviceAccountName: {{ template "multipaper-helm.serviceAccount.name" . }}
       securityContext:
-          runAsNonRoot: true
-          runAsUser: {{ .Values.master.uid }}
-          runAsGroup: {{ .Values.master.gid }}
-          fsGroup: {{ .Values.master.gid }}
+        runAsNonRoot: true
+        runAsUser: {{ .Values.master.uid }}
+        runAsGroup: {{ .Values.master.gid }}
+        fsGroup: {{ .Values.master.gid }}
       containers:
         - name: {{ .Chart.Name }}-master
           image: "{{ .Values.master.image.repository }}:{{ .Values.master.image.tag | default .Chart.AppVersion }}"

--- a/templates/multipaper-deployment.yaml
+++ b/templates/multipaper-deployment.yaml
@@ -16,10 +16,10 @@ spec:
     spec:
       serviceAccountName: {{ template "multipaper-helm.serviceAccount.name" . }}
       securityContext:
-          runAsNonRoot: true
-          runAsUser: {{ .Values.server.uid }}
-          runAsGroup: {{ .Values.server.gid }}
-          fsGroup: {{ .Values.server.gid }}
+        runAsNonRoot: true
+        runAsUser: {{ .Values.server.uid }}
+        runAsGroup: {{ .Values.server.gid }}
+        fsGroup: {{ .Values.server.gid }}
       initContainers:
         - name: copy-configuration
           image: multipaper-init:0.0.1

--- a/templates/multipaper-deployment.yaml
+++ b/templates/multipaper-deployment.yaml
@@ -16,9 +16,10 @@ spec:
     spec:
       serviceAccountName: {{ template "multipaper-helm.serviceAccount.name" . }}
       securityContext:
-          fsGroup: 1001
-          runAsUser: 1001
-          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: {{ .Values.server.uid }}
+          runAsGroup: {{ .Values.server.gid }}
+          fsGroup: {{ .Values.server.gid }}
       initContainers:
         - name: copy-configuration
           image: multipaper-init:0.0.1

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,14 @@ global:
 
 # MultiPaper master server
 master:
+  # The id of the group that will be running the master server process.
+  # By default this is 1001, multipaper user.
+  # Image dependant.
+  gid: 1001
+  # The id of the user that will be running the master server process.
+  # By default this is 1001, multipaper user.
+  # Image dependant.
+  uid: 1001
 
   # Built-in Proxy settings
   proxy:
@@ -116,6 +124,15 @@ master:
 
 # MultiPaper server
 server:
+  # The id of the group that will be running the MultiPaper server process.
+  # By default this is 1001, multipaper user.
+  # Image dependant.
+  gid: 1001
+  # The id of the user that will be running the MultiPaper server process.
+  # By default this is 1001, multipaper user.
+  # Image dependant.
+  uid: 1001
+
   image:
     repository: "multipaper"
     # Tag of the Docker image to be used.


### PR DESCRIPTION
- Run multipaper and master container as non-root multipaper users
- Add possibility to configure this user and group
- No longer possible to run as a root user