### PR TITLE
Enable console access to MultiPaper

### DIFF
--- a/templates/multipaper-deployment.yaml
+++ b/templates/multipaper-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           command: [ "java", "-jar", "/multipaper/multipaper.jar" ]
+          args: [ "nojline" ]
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           ports:
             - name: server
@@ -66,6 +67,7 @@ spec:
             successThreshold: {{ .Values.server.probes.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.server.probes.livenessProbe.timeoutSeconds }}
           {{- end }}
+          stdin: true
           volumeMounts:
             - name: multipaper-configs-data
               mountPath: /multipaper/data


### PR DESCRIPTION
Add console access to MultiPaper through kubectl attach. No TTY necessary. Minimal implementation.

JLine is disabled to allow console access. Support might be made available later on for JLine, however this will be on a best-effort basis as the current JLine version 2 is deprecated and superseded by version 3.